### PR TITLE
Make detaching in Catalyst-Authentication-Credential-GSSAPI configurable

### DIFF
--- a/lib/Catalyst/Authentication/Credential/GSSAPI.pm
+++ b/lib/Catalyst/Authentication/Credential/GSSAPI.pm
@@ -98,9 +98,10 @@ sub authenticate {
 		if ($self->_config->{strip_realm}) {
 		    $client_name =~ s/\@.+$//;
 		}
-		my $user = $realm->find_user
-		  ({ %$authinfo,
-		     $self->_config->{username_field} => $client_name });
+		my $user = $realm->find_user(
+			{ %$authinfo, $self->_config->{username_field} => $client_name }, 
+			$c
+		);
 		if ($user) {
 		    return $user;
 		} else {

--- a/lib/Catalyst/Authentication/Credential/GSSAPI.pm
+++ b/lib/Catalyst/Authentication/Credential/GSSAPI.pm
@@ -1,5 +1,5 @@
 package Catalyst::Authentication::Credential::GSSAPI;
-our $VERSION = '0.0.5';
+our $VERSION = '0.0.6';
 use strict;
 use warnings;
 


### PR DESCRIPTION
Hello,

  @wiof and I have modified C::A::C::GSSAPI to allow the following functionality:

  - Allow for the user to specify a dont_detach flag in the configuration. This permits the call to ->authenticate to continue, and the application to handle other authentication strategies if kerberos is optional
 - Pass $c to find_user, as some credential stores (non-LDAP) need the context to recover the users' information

  The changes are backwards compatible, so whoever is using this plugin will not be affected by the new dont_detach behaviour.

Please tell us what you think about this merge request